### PR TITLE
handle None status code from parallel tasks

### DIFF
--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -411,7 +411,7 @@ def execute(task, *args, **kwargs):
             # Otherwise, pull in results from the child run.
             ran_jobs = jobs.run()
             for name, d in six.iteritems(ran_jobs):
-                if d['exit_code'] != 0:
+                if d['exit_code'] not in (0, None):
                     if isinstance(d['results'], NetworkError) and \
                             _is_network_error_ignored():
                         error(d['results'].message, func=warn, exception=d['results'].wrapped)

--- a/fabric/version.py
+++ b/fabric/version.py
@@ -9,7 +9,7 @@ from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
 
-VERSION = (1, 15, 0, 'post', 1)
+VERSION = (1, 15, 1)
 
 
 def git_sha():


### PR DESCRIPTION
This pull request fixes https://github.com/Parsely/engineering/pull/6288#issuecomment-1006901026 by handling the `None` error codes that can come back from successful parallel jobs. I haven't examined the root cause of `None` as opposed to `0` in such cases.